### PR TITLE
Breadcrumbs are happening

### DIFF
--- a/components/Breadcrumbs.js
+++ b/components/Breadcrumbs.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { css } from 'react-emotion'
+
+const breadcrumb = css`
+  background-color: #ddd;
+  padding: 20px 60px 20px 60px;
+
+  ol {
+    max-width: 960px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 19px;
+
+    li {
+      display: inline-block;
+    }
+
+    li:not(:last-child)::after {
+      content: '>';
+      padding: 0 10px;
+      color: #444;
+    }
+  }
+`
+
+export default class Breadcrumbs extends React.Component {
+  constructor() {
+    super()
+    // Bind the method to the component context
+    this.renderChildren = this.renderChildren.bind(this)
+    this.getTextNode = this.getTextNode.bind(this)
+  }
+
+  getTextNode(child) {
+    if (typeof child === 'string') {
+      return child
+    }
+    if (!child || !child.props) {
+      return ''
+    }
+    return React.Children.map(child.props.children, child => {
+      return this.getTextNode(child)
+    }).join('')
+  }
+
+  renderChildren() {
+    return React.Children.map(this.props.children, (child, i) => {
+      return (
+        <li>
+          {this.props.children.length === i + 1
+            ? this.getTextNode(child)
+            : child}
+        </li>
+      )
+    })
+  }
+
+  /* https://stackoverflow.com/questions/27366077/only-allow-children-of-a-specific-type-in-a-react-component/36424582#36424582 */
+
+  render() {
+    return (
+      /* make sure at least 1 child */
+      <section className={breadcrumb}>
+        <nav aria-label="Breadcrumb">
+          <ol>{this.renderChildren()}</ol>
+        </nav>
+      </section>
+    )
+  }
+}

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import Layout from '../components/Layout'
 import { hydrate } from 'react-emotion'
-import AlphaBanner from '../components/AlphaBanner'
-import FederalBanner from '../components/FederalBanner'
 import Link from 'next/link'
 import { GoCSignature } from '@cdssnc/gcui'
+
+import Layout from '../components/Layout'
+import AlphaBanner from '../components/AlphaBanner'
+import FederalBanner from '../components/FederalBanner'
+import Breadcrumbs from '../components/Breadcrumbs'
 import Footer from '../components/Footer'
 
 // Adds server generated styles to emotion cache.
@@ -15,22 +17,14 @@ if (typeof window !== 'undefined' && window.__NEXT_DATA__) {
 
 const SearchPage = () => (
   <Layout title="Search">
-    <section>
-      <nav aria-label="Breadcrumb">
-        <ol>
-          <li>
-            <Link href="/">
-              <a>EnerGuide API</a>
-            </Link>
-          </li>
-          <li>
-            <Link href="/search">
-              <a aria-current="page">Search</a>
-            </Link>
-          </li>
-        </ol>
-      </nav>
-    </section>
+    <Breadcrumbs>
+      <Link href="/">
+        <a>EnerGuide API</a>
+      </Link>
+      <Link href="/search">
+        <a>Search</a>
+      </Link>
+    </Breadcrumbs>
 
     <div id="page-body">
       <header>


### PR DESCRIPTION
🍞 > 🍞 > 🍞

They're accessible and they use `children` so they scale pretty well. Hopefully we can move this relatively unaltered to the new repo.